### PR TITLE
client cannot actually make use of AnnounceRoute()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bak
 *~
 .idea/
 cover.out
+/vendor


### PR DESCRIPTION
Fix the issue that client cannot actually make use of AnnounceRoute()

The implementation of AnnounceRoute() does not include the part that actually allow client to generate and send update messages. It only worked for servers to redistribute routes to client.


In the CLI version, without sleeping, the announcement is actually done via the for loop in SetState, not via AnnounceRoute(). 