### PR TITLE
Use golang 1.17 instead of 1.18

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.17'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.17'
       - run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye as builder
+FROM golang:1.17-bullseye as builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docker:
 	docker build -t onmetal/metalbond .
 
 deb:
-	docker run -it --rm -v "$(PWD):/workdir" -e "METALBOND_VERSION=$(METALBOND_VERSION)" golang:1.18-bullseye bash -c "cd /workdir && deb/make-deb.sh"
+	docker run -it --rm -v "$(PWD):/workdir" -e "METALBOND_VERSION=$(METALBOND_VERSION)" golang:1.17-bullseye bash -c "cd /workdir && deb/make-deb.sh"
 
 unit-test:
 	go test -v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onmetal/metalbond
 
-go 1.18
+go 1.17
 
 require (
 	github.com/alecthomas/kong v0.5.0


### PR DESCRIPTION
# Proposed Changes

Use golang 1.17 instead of 1.18. 

/cc @hardikdr @byteocean 