### PR TITLE
Add API to retrieve current state route subscription

### DIFF
--- a/metalbond.go
+++ b/metalbond.go
@@ -131,9 +131,24 @@ func (m *MetalBond) Subscribe(vni VNI) error {
 	return nil
 }
 
+func (m *MetalBond) IsSubscribed(vni VNI) bool {
+	m.mtxMySubscriptions.Lock()
+	defer m.mtxMySubscriptions.Unlock()
+
+	if _, exists := m.mySubscriptions[vni]; exists {
+		return true
+	}
+
+	return false
+}
+
 func (m *MetalBond) Unsubscribe(vni VNI) error {
 	m.log().Errorf("Unsubscribe not implemented (VNI %d)", vni)
 	return nil
+}
+
+func (m *MetalBond) IsRouteAnnounced(vni VNI, dest Destination, hop NextHop) bool {
+	return m.myAnnouncements.NextHopExists(vni, dest, hop, nil)
 }
 
 func (m *MetalBond) AnnounceRoute(vni VNI, dest Destination, hop NextHop) error {


### PR DESCRIPTION
Calls for retrieving the current state of data structures make the life for reconcile loops easier.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>

# Proposed Changes

Reconcile loops of metalnet needs the ability to query the state of metalbond. This is quite 
useful e.g when the metalnet resources are already in desired state and in that case they 
can exit the reconcile loop early, if they can query the current state of metalbond. 


Fixes #