### PR TITLE
Add function to get subscribed vnis as a client

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.18'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.18'
       - run: make
       - run: make test

--- a/metalbond.go
+++ b/metalbond.go
@@ -40,8 +40,7 @@ type MetalBond struct {
 
 	keepaliveInterval uint32
 	shuttingDown      bool
-
-	client Client
+	client            Client
 
 	lis      *net.Listener // for server only
 	isServer bool
@@ -308,6 +307,18 @@ func (m *MetalBond) GetRoutesForVni(vni VNI) error {
 		}
 	}
 	return nil
+}
+
+func (m *MetalBond) GetSubscribedVnis() []VNI {
+	m.mtxMySubscriptions.RLock()
+	defer m.mtxMySubscriptions.RUnlock()
+
+	vnis := make([]VNI, 0)
+	for vni := range m.mySubscriptions {
+		vnis = append(vnis, vni)
+	}
+
+	return vnis
 }
 
 func (m *MetalBond) addReceivedRoute(fromPeer *metalBondPeer, vni VNI, dest Destination, hop NextHop) error {


### PR DESCRIPTION
Added a helper function to get subscribed VNIs in the cache, a corresponding test is included.

CI/CD relevant files are modified to be consistent with the Go version specified in the project and to make the pipeline working.