### PR TITLE
add marshaler methods for Destination struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -4,6 +4,7 @@
 package metalbond
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"net/netip"
@@ -21,6 +22,16 @@ type VNI uint32
 type Destination struct {
 	IPVersion IPVersion
 	Prefix    netip.Prefix
+}
+
+func (d Destination) MarshalText() (text []byte, err error) {
+	type x Destination
+	return json.Marshal(x(d))
+}
+
+func (d *Destination) UnmarshalText(text []byte) error {
+	type x Destination
+	return json.Unmarshal(text, (*x)(d))
 }
 
 func (d Destination) String() string {


### PR DESCRIPTION
Fixes #92

Issue caused by changing key of map from `string` to `struct` of type `Destination` which didn't implement `encoding.TextMarshaler` so json was not able to marshal this struct.
`MarshalText` and `UnmarshalText` methods for `Destination` were added to fix this problem.