### PR TITLE
Introduce HA support

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,6 +86,7 @@ func main() {
 		log.Infof("Client")
 		log.Infof("  servers: %v", CLI.Client.Server)
 		var err error
+		var serverCount = 0
 
 		if CLI.Client.Verbose {
 			log.SetLevel(log.DebugLevel)
@@ -139,6 +140,10 @@ func main() {
 		}
 
 		for _, server := range CLI.Client.Server {
+			serverCount++
+			if serverCount == 3 {
+				panic(fmt.Errorf("can not connect to more than 2 servers"))
+			}
 			if err := m.AddPeer(server, ""); err != nil {
 				panic(fmt.Errorf("failed to add server: %v", err))
 			}


### PR DESCRIPTION
Change the client behaviour in such a way that in case a second metalbond server distributing the exact same routes as the "main" server is added to the server list then the client is aware of the second server when adding removing the routes from its routing table hence withdraws already received routes only if both servers withdraw the routes in question.

Single server operation is same as before. (Backward compatible)
