### PR TITLE
Necessary changes to support vni peering in metalnet after non-reflect routing change

### DIFF
--- a/metalbond.go
+++ b/metalbond.go
@@ -284,7 +284,13 @@ func (m *MetalBond) distributeRouteToPeers(action UpdateAction, vni VNI, dest De
 	return nil
 }
 
-func (m *MetalBond) GetRoutesForVni(vni VNI) error {
+func (m *MetalBond) GetClient() Client {
+	return m.client
+}
+
+// This function re-adds routes, including announced and received ones
+func (m *MetalBond) AddRoutesForVni(vni VNI) error {
+	// re-add received routes for this VNI
 	for dest, hops := range m.routeTable.GetDestinationsByVNI(vni) {
 		for _, hop := range hops {
 			err := m.client.AddRoute(vni, dest, hop)
@@ -294,6 +300,17 @@ func (m *MetalBond) GetRoutesForVni(vni VNI) error {
 			}
 		}
 	}
+	// re-add announced routes for this VNI
+	for dest, hops := range m.myAnnouncements.GetDestinationsByVNI(vni) {
+		for _, hop := range hops {
+			err := m.client.AddRoute(vni, dest, hop)
+			if err != nil {
+				m.log().Errorf("Client.AddRoute call failed in Refill for myAnnouncements: %v", err)
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Support getting metalbond client instance and re-addroute due to peering purposes in metalnet.

a new release containing these changes is also needed for metalnet

Additional context from discussions:

> 1) what is function used for? This function is used when new VNI peering, e.g., VNI 1001 newly peered with VNI 1000, is detected. Routes belonging to each VNI need to be examined and populated into the corresponding routing tables of the other VNI. This function needs to be actively called by a metalbond client implementation. In this case, the metalbond client is metalnet. Meanwhile, inside this function, different clients also have different implementations for `AddRoute(vni, dest, hop)`, which determines the actual behaviors. In this case, metalnet's implementation of `AddRoute` contains the logic for peering routes processing.
>
> 2) why announced routes are needed now? It is because of the non-reflecting route changes in metalbond. Since self-announced routes are not reflected back, they cannot be found in received route table. In order to provide all available routes from one VNI to another VNI, we also need to iterate through announced route table.
>
> 3) what is the impact on other clients, e.g., netlink one? No impact. This function needs to be called, instead of being triggered via a callback mechanism. Netlink client does not call this function at all, but only metalnet client does. I think this behavior also fits our discussion result, where we should let clients have different route processing logics to some degree.
>
> 4) why it is in metalbond? It is convenient. As metalbond contains main logic for a client, it has access to tables of announced and received routes.