### PR TITLE
Fix release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,25 +1,30 @@
-name: Release Drafter
-
-on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
+    name: Run release drafter
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Labels PRs based on branch, title, files, and body patterns
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        if: github.event_name == 'pull_request_target'
+        with:
+          config-name: release-drafter.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      # or a release branch
       - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # https://github.com/release-drafter/release-drafter
+          # token is one of the action inputs
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use `pull-request-target` as a trigger event for release drafter, otherwise the drafter runs against an ephemeral refs/pull/XYZ/merge reference.
Use autolabeler on each pull request explicitly.
