### PR TITLE
Prevent routing loops by avoiding self-announced routes

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,6 +86,11 @@ func main() {
 		m.Shutdown()
 
 	case "client":
+		// Subscriptions and announcements are registered before peers are
+		// added. When a peer connects, it syncs both automatically. This
+		// ensures myAnnouncements is populated before any routes arrive,
+		// which is required for the loop-prevention check in
+		// addReceivedRoute.
 		log.Infof("Client")
 		log.Infof("  servers: %v", CLI.Client.Server)
 		var err error
@@ -139,32 +144,6 @@ func main() {
 			if err := m.StartHTTPServer(CLI.Client.Http); err != nil {
 				panic(fmt.Errorf("failed to start http server: %v", err))
 			}
-		}
-
-		for _, server := range CLI.Client.Server {
-			if err := m.AddPeer(server, ""); err != nil {
-				panic(fmt.Errorf("failed to add server: %v", err))
-			}
-		}
-
-		// Wait for all peers to connect
-		deadline := time.Now().Add(10 * time.Second)
-		for {
-			connected := true
-			for _, server := range CLI.Client.Server {
-				state, err := m.PeerState(server)
-				if err != nil || state != metalbond.ESTABLISHED {
-					connected = false
-					break
-				}
-			}
-			if connected {
-				break
-			}
-			if time.Now().After(deadline) {
-				panic(errors.New("timeout waiting to connect"))
-			}
-			time.Sleep(1 * time.Second)
 		}
 
 		for _, subscription := range CLI.Client.Subscribe {
@@ -236,6 +215,32 @@ func main() {
 			if err := m.AnnounceRoute(metalbond.VNI(vni), dest, hop); err != nil {
 				log.Fatalf("failed to announce route: %v", err)
 			}
+		}
+
+		for _, server := range CLI.Client.Server {
+			if err := m.AddPeer(server, ""); err != nil {
+				panic(fmt.Errorf("failed to add server: %v", err))
+			}
+		}
+
+		// Wait for all peers to connect
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			connected := true
+			for _, server := range CLI.Client.Server {
+				state, err := m.PeerState(server)
+				if err != nil || state != metalbond.ESTABLISHED {
+					connected = false
+					break
+				}
+			}
+			if connected {
+				break
+			}
+			if time.Now().After(deadline) {
+				panic(errors.New("timeout waiting to connect"))
+			}
+			time.Sleep(1 * time.Second)
 		}
 
 		// Wait for SIGINTs

--- a/metalbond.go
+++ b/metalbond.go
@@ -327,6 +327,11 @@ func (m *MetalBond) GetSubscribedVnis() []VNI {
 }
 
 func (m *MetalBond) addReceivedRoute(fromPeer *metalBondPeer, vni VNI, dest Destination, hop NextHop) error {
+	if len(m.myAnnouncements.GetNextHopsByDestination(vni, dest)) > 0 {
+		m.log().Debugf("Skipping received route VNI %d %s via %s: we already announce this destination", vni, dest, hop)
+		return nil
+	}
+
 	err := m.routeTable.AddNextHop(vni, dest, hop, fromPeer)
 	if err != nil {
 		return fmt.Errorf("cannot add route to route table: %v", err)

--- a/peer_test.go
+++ b/peer_test.go
@@ -16,6 +16,41 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type TrackingClient struct {
+	mtx    sync.Mutex
+	routes map[VNI]map[Destination][]NextHop
+}
+
+func NewTrackingClient() *TrackingClient {
+	return &TrackingClient{
+		routes: make(map[VNI]map[Destination][]NextHop),
+	}
+}
+
+func (c *TrackingClient) AddRoute(vni VNI, dest Destination, nexthop NextHop) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.routes[vni] == nil {
+		c.routes[vni] = make(map[Destination][]NextHop)
+	}
+	c.routes[vni][dest] = append(c.routes[vni][dest], nexthop)
+	return nil
+}
+
+func (c *TrackingClient) RemoveRoute(vni VNI, dest Destination, nexthop NextHop) error {
+	return nil
+}
+
+func (c *TrackingClient) HasRoute(vni VNI, dest Destination) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.routes[vni] == nil {
+		return false
+	}
+	_, exists := c.routes[vni][dest]
+	return exists
+}
+
 var _ = Describe("Peer", func() {
 
 	var (
@@ -340,3 +375,73 @@ func incrementIPv4(ip net.IP, count int) net.IP {
 	}
 	return ip
 }
+
+var _ = Describe("Route Filtering", func() {
+	var (
+		mbServer      *MetalBond
+		serverAddress string
+	)
+
+	BeforeEach(func() {
+		log.Info("----- START Route Filtering -----")
+		config := Config{}
+		mbServer = NewMetalBond(config, NewDummyClient())
+		serverAddress = fmt.Sprintf("127.0.0.1:%d", getRandomTCPPort())
+		err := mbServer.StartServer(serverAddress)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		mbServer.Shutdown()
+	})
+
+	It("should not install routes for destinations already announced", func() {
+		vni := VNI(100)
+
+		client1 := NewTrackingClient()
+		client2 := NewTrackingClient()
+
+		mbClient1 := NewMetalBond(Config{}, client1)
+		mbClient2 := NewMetalBond(Config{}, client2)
+
+		err := mbClient1.AddPeer(serverAddress, "127.0.0.2")
+		Expect(err).NotTo(HaveOccurred())
+		err = mbClient2.AddPeer(serverAddress, "127.0.0.3")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(waitForPeerState(mbClient1, serverAddress, ESTABLISHED)).To(BeTrue())
+		Expect(waitForPeerState(mbClient2, serverAddress, ESTABLISHED)).To(BeTrue())
+
+		err = mbClient1.Subscribe(vni)
+		Expect(err).NotTo(HaveOccurred())
+		err = mbClient2.Subscribe(vni)
+		Expect(err).NotTo(HaveOccurred())
+
+		dest := Destination{
+			Prefix:    netip.MustParsePrefix("0.0.0.0/0"),
+			IPVersion: IPV4,
+		}
+
+		nextHop1 := NextHop{
+			TargetVNI:     uint32(vni),
+			TargetAddress: netip.MustParseAddr("fd00::1"),
+		}
+		nextHop2 := NextHop{
+			TargetVNI:     uint32(vni),
+			TargetAddress: netip.MustParseAddr("fd00::2"),
+		}
+
+		err = mbClient1.AnnounceRoute(vni, dest, nextHop1)
+		Expect(err).NotTo(HaveOccurred())
+		err = mbClient2.AnnounceRoute(vni, dest, nextHop2)
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(3 * time.Second)
+
+		Expect(client1.HasRoute(vni, dest)).To(BeFalse(), "client1 should not have installed route for destination it announces")
+		Expect(client2.HasRoute(vni, dest)).To(BeFalse(), "client2 should not have installed route for destination it announces")
+
+		mbClient1.Shutdown()
+		mbClient2.Shutdown()
+	})
+})


### PR DESCRIPTION
When two routers announce a default route into a VNI which they are both subscribed to, they would both install the default route of the other creating a loop. This commit adds a check that routes which have the same destinations as routes announced by us are not installed into the route table.