### PR TITLE
Insert alternative route if currently installed one is retracted

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -14,10 +14,21 @@ import (
 
 const METALBOND_RT_PROTO netlink.RouteProtocol = 254
 
+type routeKey struct {
+	vni  VNI
+	dest Destination
+}
+
+type routeState struct {
+	installed NextHop
+	hops      map[NextHop]struct{}
+}
+
 type NetlinkClient struct {
 	config    NetlinkClientConfig
 	tunDevice netlink.Link
 	mtx       sync.Mutex
+	routes    map[routeKey]*routeState
 }
 
 type NetlinkClientConfig struct {
@@ -38,6 +49,7 @@ func NewNetlinkClient(config NetlinkClientConfig) (*NetlinkClient, error) {
 	return &NetlinkClient{
 		config:    config,
 		tunDevice: link,
+		routes:    make(map[routeKey]*routeState),
 	}, nil
 }
 
@@ -55,28 +67,23 @@ func (c *NetlinkClient) AddRoute(vni VNI, dest Destination, hop NextHop) error {
 		return fmt.Errorf("no route table ID known for given VNI")
 	}
 
-	_, dst, err := net.ParseCIDR(dest.Prefix.String())
+	key := routeKey{vni: vni, dest: dest}
+	state, exists := c.routes[key]
+	if !exists {
+		state = &routeState{hops: make(map[NextHop]struct{})}
+		c.routes[key] = state
+	}
+	state.hops[hop] = struct{}{}
+
+	if len(state.hops) > 1 {
+		return nil
+	}
+
+	err := c.installRoute(dest, hop, table)
 	if err != nil {
-		return fmt.Errorf("cannot parse destination prefix: %v", err)
+		return err
 	}
-
-	encap := netlink.IP6tnlEncap{
-		Dst: net.ParseIP(hop.TargetAddress.String()),
-		Src: net.ParseIP("::"), // what source ip to put here? Metalbond object, m, does not contain this info yet.
-	}
-
-	route := &netlink.Route{
-		LinkIndex: c.tunDevice.Attrs().Index,
-		Dst:       dst,
-		Encap:     &encap,
-		Table:     table,
-		Protocol:  METALBOND_RT_PROTO,
-	} // by default, the route is already installed into the kernel table without explicite specification
-
-	if err := netlink.RouteAdd(route); err != nil {
-		return fmt.Errorf("cannot add route to %s (table %d) to kernel: %v", dest, table, err)
-	}
-
+	state.installed = hop
 	return nil
 }
 
@@ -93,6 +100,45 @@ func (c *NetlinkClient) RemoveRoute(vni VNI, dest Destination, hop NextHop) erro
 		return fmt.Errorf("no route table ID known for given VNI")
 	}
 
+	key := routeKey{vni: vni, dest: dest}
+	state, exists := c.routes[key]
+	if !exists {
+		return fmt.Errorf("no routes known for VNI %d dest %s", vni, dest)
+	}
+
+	delete(state.hops, hop)
+
+	if state.installed != hop {
+		if len(state.hops) == 0 {
+			delete(c.routes, key)
+		}
+		return nil
+	}
+
+	if len(state.hops) == 0 {
+		delete(c.routes, key)
+		err := c.uninstallRoute(dest, hop, table)
+		if err != nil {
+			return fmt.Errorf("cannot remove route to %s from kernel: %v", dest, err)
+		}
+		return nil
+	}
+
+	var replacement NextHop
+	for nh := range state.hops {
+		replacement = nh
+		break
+	}
+
+	err := c.replaceRoute(dest, replacement, table)
+	if err != nil {
+		return fmt.Errorf("cannot install replacement route for %s: %v", dest, err)
+	}
+	state.installed = replacement
+	return nil
+}
+
+func (c *NetlinkClient) installRoute(dest Destination, hop NextHop, table int) error {
 	_, dst, err := net.ParseCIDR(dest.Prefix.String())
 	if err != nil {
 		return fmt.Errorf("cannot parse destination prefix: %v", err)
@@ -100,7 +146,7 @@ func (c *NetlinkClient) RemoveRoute(vni VNI, dest Destination, hop NextHop) erro
 
 	encap := netlink.IP6tnlEncap{
 		Dst: net.ParseIP(hop.TargetAddress.String()),
-		Src: net.ParseIP("::"), // what source ip to put here? Metalbond object, m, does not contain this info yet.
+		Src: net.ParseIP("::"),
 	}
 
 	route := &netlink.Route{
@@ -109,10 +155,62 @@ func (c *NetlinkClient) RemoveRoute(vni VNI, dest Destination, hop NextHop) erro
 		Encap:     &encap,
 		Table:     table,
 		Protocol:  METALBOND_RT_PROTO,
-	} // by default, the route is already installed into the kernel table without explicite specification
+	}
+
+	if err := netlink.RouteAdd(route); err != nil {
+		return fmt.Errorf("cannot add route to %s (table %d) to kernel: %v", dest, table, err)
+	}
+
+	return nil
+}
+
+func (c *NetlinkClient) uninstallRoute(dest Destination, hop NextHop, table int) error {
+	_, dst, err := net.ParseCIDR(dest.Prefix.String())
+	if err != nil {
+		return fmt.Errorf("cannot parse destination prefix: %v", err)
+	}
+
+	encap := netlink.IP6tnlEncap{
+		Dst: net.ParseIP(hop.TargetAddress.String()),
+		Src: net.ParseIP("::"),
+	}
+
+	route := &netlink.Route{
+		LinkIndex: c.tunDevice.Attrs().Index,
+		Dst:       dst,
+		Encap:     &encap,
+		Table:     table,
+		Protocol:  METALBOND_RT_PROTO,
+	}
 
 	if err := netlink.RouteDel(route); err != nil {
 		return fmt.Errorf("cannot remove route to %s (table %d) from kernel: %v", dest, table, err)
+	}
+
+	return nil
+}
+
+func (c *NetlinkClient) replaceRoute(dest Destination, hop NextHop, table int) error {
+	_, dst, err := net.ParseCIDR(dest.Prefix.String())
+	if err != nil {
+		return fmt.Errorf("cannot parse destination prefix: %v", err)
+	}
+
+	encap := netlink.IP6tnlEncap{
+		Dst: net.ParseIP(hop.TargetAddress.String()),
+		Src: net.ParseIP("::"),
+	}
+
+	route := &netlink.Route{
+		LinkIndex: c.tunDevice.Attrs().Index,
+		Dst:       dst,
+		Encap:     &encap,
+		Table:     table,
+		Protocol:  METALBOND_RT_PROTO,
+	}
+
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("cannot replace route to %s (table %d) in kernel: %v", dest, table, err)
 	}
 
 	return nil


### PR DESCRIPTION
When multiple next-hops for a route are announced via metalbond the netlink client tries to install every one of them, but only the first one succeeds as the kernel only allows one route entry per prefix. Any next-hops that are announced after the first one log an error and never get installed.

This commit enhances the netlink client to track the routes which have been added / removed and be aware that only one route can be installed into the kernel. If the route currently installed is removed later on, it installs one of the other cached next-hops in its place to ensure traffic continues to flow.

As a long-term solution we should add proper multi-path support as described in issue 16.

Fixes: https://github.com/ironcore-dev/metalbond/issues/183
Link: https://github.com/ironcore-dev/metalbond/issues/16