### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ironcore-dev/network-maintainers @ironcore-dev/network-contributors

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,6 +12,7 @@ path = [
     ".vscode/settings.json",
     "Dockerfile",
     "Makefile",
+    "CODEOWNERS",
     "go.mod",
     "go.sum",
     "debian/**",


### PR DESCRIPTION
Set the network-maintainers team as codeowner to ensure they are automatically assigned to new pull requests.