### PR TITLE
Remove all path filters and pin GitHub Actions

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -13,7 +13,7 @@ jobs:
         architecture: [ amd64, arm64 ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build DEB Package
         run: make deb
@@ -21,7 +21,7 @@ jobs:
           METALBOND_VERSION: "${{ inputs.version }}"
 
       - name: Upload for next actions job
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
           name: metalbond_${{ inputs.version }}_${{ matrix.architecture }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,9 +2,7 @@ name: Lint Golang Codebase
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,13 +8,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -20,8 +20,8 @@ jobs:
       (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'ok-to-image') || contains(github.event.pull_request.labels.*.name, 'ok-to-🐳')))
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: docker/metadata-action@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       id: meta
       with:
         images: |
@@ -37,7 +37,7 @@ jobs:
           latest=${{ github.ref == 'refs/heads/main' }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       with:
         platforms: all
     # workaround for self-hosted runner
@@ -50,14 +50,14 @@ jobs:
 
     - name: Set up Docker Buildx
       timeout-minutes: 5
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       with:
         version: latest
         endpoint: builders # self-hosted
 
     - name: Login to GHCR
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
 
     - name: Build and push
       timeout-minutes: 40
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         build-args: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,15 +6,9 @@ on:
     - main
     tags:
     - v*
-    paths-ignore:
-    - 'docs/**'
-    - '**/*.md'
   pull_request:
     types:
     - labeled
-    paths-ignore:
-    - 'docs/**'
-    - '**/*.md'
 
 jobs:
   buildAndPush:

--- a/.github/workflows/publish-to-github-releases.yml
+++ b/.github/workflows/publish-to-github-releases.yml
@@ -13,19 +13,19 @@ jobs:
         architecture: [ amd64, arm64 ]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get Release
         id: get_release
-        uses: bruceadams/get-release@v1.3.2
+        uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f # v1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: metalbond_${{ inputs.version }}_${{ matrix.architecture }}
 
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with: 
           files: metalbond_${{ inputs.version }}_${{ matrix.architecture }}.deb

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Labels PRs based on branch, title, files, and body patterns
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         if: github.event_name == 'pull_request_target'
         with:
           config-name: release-drafter.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       # or a release branch
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         with:
           config-name: release-drafter.yml
           # https://github.com/release-drafter/release-drafter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Versions      
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: set_version
         with:
           script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,8 @@ on:
   push:
     branches:
     - '*'
-
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   checks:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     name: run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
       - run: make


### PR DESCRIPTION
Since path filtering in GitHub Actions Workflows clashes hard with the required workflow setting we simply run the workflows every time. The amount of changes that only touch documentation is rather low, so the savings have been minor either way.